### PR TITLE
fix(FRO-52): Adjust alignment of the loader

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -76,7 +76,7 @@ function App() {
 
   if (appLoading) {
     return (
-      <div style={{ display: "flex", justifyContent: "center" }}>
+      <div style={{ display: "flex", justifyContent: "center", marginTop: "250px" }}>
         <Loader />
       </div>
     );


### PR DESCRIPTION
This commit will centralize the loader to be in the middle for blank pages.

https://user-images.githubusercontent.com/50625848/205042876-e57fcc5d-9208-44a7-8b96-bee1ef027d88.mp4

