### PR TITLE
Feat(BE-54): Added unique link to certificates

### DIFF
--- a/Backend/models/certificateModel.js
+++ b/Backend/models/certificateModel.js
@@ -7,7 +7,7 @@ const CertificateSchema = new mongoose.Schema({
         type: String,
         required: [true, 'Name of recipient is required']
     },
-    nameOfOrganization: {
+    nameoforganization: {
         type: String,
         required: [true, 'Name of organization (issuer) is required']
     },
@@ -34,6 +34,12 @@ const CertificateSchema = new mongoose.Schema({
       type: String,
       enum: [ 'pending', 'issued', 'canceled' ],
       default: 'pending'
+    },
+    uuid: {
+      type: String
+    },
+    link: {
+      type: String
     }
   }],
   userId:{

--- a/Backend/utils/validation.js
+++ b/Backend/utils/validation.js
@@ -7,6 +7,8 @@ const isValidJsonOutput = (jsonArray) => {
     "signed",
     "email",
     "date",
+    "uuid",
+    "link"
   ];
 
   const csvHeadersCount = Object.keys(jsonArray[0]).length;


### PR DESCRIPTION
BE-54 (https://linear.app/team-headlight/issue/BE-54/verifiable-uri-for-certificate)
Added a unique link to the certificate:

It adds a unique link for each certificate so that users can share that unique link of a particular certificate on social media platforms e.g Twitter, LinkedIn.

Mongodb certificate models were modified and 2 new values were introduced which are uuid and link
CSV file should be uploaded as form-data with the key name *file*
Endpoint uses a POST method via /api/certificates


