### PR TITLE
Fix be 66 remove redundant cert collection

### DIFF
--- a/Backend/models/eventModel.js
+++ b/Backend/models/eventModel.js
@@ -6,11 +6,6 @@ const EventSchema = new Schema({
     type: String,
     requried: true,
   },
-  certCollectionId: {
-    type: Schema.Types.ObjectId,
-    required: true,
-    ref: "Certificate",
-  },
   userId: {
     type: Schema.Types.ObjectId,
     required: true,


### PR DESCRIPTION
I removed certCollectionId from the event Model and controller because it has become obsolete due to the fact that each user has only one certificate collection. As a result, I have made changes to the events model and controllers to factor in this new development