### PR TITLE
feat: consumed endpoint for deleting user certificates

### DIFF
--- a/frontend/src/pages/Dashboard/index.jsx
+++ b/frontend/src/pages/Dashboard/index.jsx
@@ -58,6 +58,17 @@ const Dashboard = ({
     setData(res.data);
   };
   
+  const handleDeleteCertificate = async (id) => {
+    console.log(id);
+    await axiosPrivate.delete(`/certificates/${id}`);
+    Toast.fire({
+      icon: "success",
+      title: "Successfully deleted"
+    });
+    const res = await axiosPrivate.get("/certificates");
+    setData(res.data);
+  };
+
   useEffect(() => {
     const getUserCertificates = async () => {
       try {
@@ -226,6 +237,7 @@ const Dashboard = ({
                       item={item}
                       key={idx}
                       handleChangeCertificateStatus={handleChangeCertificateStatus}
+                      handleDeleteCertificate={handleDeleteCertificate}
                     />
                   ))}
                 </tbody>


### PR DESCRIPTION
I have integrated the endpoint for deleting generated user certificates. This is done by: 

- Sending a private axios delete function to the api using the certificate id 
- Getting the updated list of certificates
- Rendering the new list of certificates