### PR TITLE
feat: Add modal to download bulk certificates

### DIFF
--- a/frontend/src/pages/BulkPreview/index.jsx
+++ b/frontend/src/pages/BulkPreview/index.jsx
@@ -1,5 +1,5 @@
 import jsPDF from "jspdf";
-import Swal from "sweetalert2";
+// import Swal from "sweetalert2";
 import { toPng } from "html-to-image";
 // import ReactToPrint from "react-to-print";
 import * as htmlToImage from "html-to-image";
@@ -60,6 +60,11 @@ function Index() {
   const bulkCertDesignRef = useRef();
 
   const handleClick = useCallback(() => {
+    if (!isAuntheticated) {
+      setOpenModal(true);
+      setModalMessage("You need to sign up to send certificate to your mail");
+      return;
+    }
     setLoading(true);
     if (bulkCertDesignRef.current === null) {
       setLoading(false);
@@ -77,9 +82,14 @@ function Index() {
         setLoading(false);
         console.log(err)
       })
-  }, [bulkCertDesignRef]);
+  }, [bulkCertDesignRef, isAuntheticated]);
 
   const downloadMultiplePdfs = async () => {
+    if (!isAuntheticated) {
+      setOpenModal(true);
+      setModalMessage("You need to sign up to send certificate to your mail");
+      return;
+    }
     const doc = new jsPDF("p", "px", [339.4, 339.4]); // Initialize a new jsPDF instance
     const elements = document.getElementsByClassName("multiple"); // Get all certificates as HTML Elements
     setLoading(true);


### PR DESCRIPTION
The feature for a modal pop up to be displayed asking unauthenticated users to either signup or login if they want to download bulk certificates has been added.
[Screencast from 11-12-2022 05:36:22.webm](https://user-images.githubusercontent.com/50625848/206886683-adb42129-c522-44c8-9bec-318a07b00a6f.webm)
